### PR TITLE
Adds field identifier support to assessment node models

### DIFF
--- a/src/lib/types/assessment-node.types.ts
+++ b/src/lib/types/assessment-node.types.ts
@@ -15,6 +15,8 @@ export interface AssessmentNodeCreateModel {
     CorrectAnswer?: number | string | boolean;
     RawData?: string;
     Required?: boolean;
+    FieldIdentifier?: string;
+    FieldIdentifierUnit?: string;
 };
 
 export interface AssessmentNodeUpdateModel {
@@ -31,7 +33,9 @@ export interface AssessmentNodeUpdateModel {
     ScoringApplicable?: boolean;
     Options?: string[];
     Tags?: string[];
-    CorrectAnswer?: number|string|boolean;
+    CorrectAnswer?: number | string | boolean;
     RawData?: string;
     Required?: boolean;
+    FieldIdentifier?: string;
+    FieldIdentifierUnit?: string;
 };

--- a/src/lib/validation/assessment-node.schema.ts
+++ b/src/lib/validation/assessment-node.schema.ts
@@ -112,6 +112,17 @@ export const createOrUpdateSchema = z.object({
                 invalid_type_error: "CorrectAnswer must be a number or boolean."
             })
         ])
-        .optional()
-    
+        .optional(),
+
+    FieldIdentifier: z
+        .string()
+        // .min(1, { message: "FieldIdentifier cannot be empty." })
+        // .max(128, { message: "FieldIdentifier must be at most 128 characters long." })
+        .optional(),
+
+    FieldIdentifierUnit: z
+        .string()
+        // .min(1, { message: "FieldIdentifierUnit cannot be empty." })
+        // .max(128, { message: "FieldIdentifierUnit must be at most 128 characters long." })
+        .optional(),
 });

--- a/src/routes/api/server/assessments/assessment-nodes/+server.ts
+++ b/src/routes/api/server/assessments/assessment-nodes/+server.ts
@@ -45,7 +45,9 @@ export const POST = async (event: RequestEvent) => {
 			data.Required,
 			data.ScoringApplicable,
 			data.ResolutionScore,
-			data.ProviderAssessmentCode
+			data.ProviderAssessmentCode,
+			data.FieldIdentifier,
+			data.FieldIdentifierUnit
 		);
 
 		return ResponseHandler.success(response);

--- a/src/routes/api/server/assessments/assessment-nodes/[id]/+server.ts
+++ b/src/routes/api/server/assessments/assessment-nodes/[id]/+server.ts
@@ -105,6 +105,11 @@ export const PUT = async (event: RequestEvent) => {
             data.ServeListNodeChildrenAtOnce,
             data.CorrectAnswer,
             data.RawData,
+            data.ScoringApplicable,
+            data.ResolutionScore,
+            data.ProviderAssessmentCode,
+            data.FieldIdentifier,
+            data.FieldIdentifierUnit
         );
 
         return ResponseHandler.success(response);

--- a/src/routes/api/server/assessments/assessment-templates/[id]/+server.ts
+++ b/src/routes/api/server/assessments/assessment-templates/[id]/+server.ts
@@ -1,11 +1,9 @@
 import { ResponseHandler } from "$lib/utils/response.handler";
 import { uuidSchema } from "$lib/validation/common.schema";
 import type { RequestEvent } from "@sveltejs/kit";
-// import { getHealthSystemById, updateHealthSystem } from "../../../services/rean-care/health.systems";
-// import type { HealthSystemUpdateModel } from "$lib/types/health.system.types";
-import { createOrUpdateSchema } from "$lib/validation/health.system.schema";
 import { deleteAssessmentTemplate, getAssessmentTemplateById, updateAssessmentTemplate } from "../../../../services/reancare/assessments/assessment-templates";
 import type { AssessmentTemplateUpdateModel } from "$lib/types/assessment-template.types";
+import { createOrUpdateSchema } from "$lib/validation/assessment.template.schema";
 
 ///////////////////////////////////////////////////////////////////////////////
 
@@ -87,6 +85,7 @@ export const PUT = async (event: RequestEvent) => {
             });
         }
 
+        console.log("validationResult", validationResult);
         const response = await updateAssessmentTemplate(
             sessionId,
             templateId,

--- a/src/routes/api/services/reancare/assessments/assessment-nodes.ts
+++ b/src/routes/api/services/reancare/assessments/assessment-nodes.ts
@@ -17,12 +17,14 @@ export const createAssessmentNode = async (
 	queryType?: string,
 	options?: string[],
 	sequence?: number,
-	correctAnswer?: number|boolean,
+	correctAnswer?: number | boolean | string,
 	rawData?: string,
 	required?: boolean,
 	scoringApplicable?: boolean,
 	resolutionScore?: number,
-	providerAssessmentCode?: string
+	providerAssessmentCode?: string,
+	fieldIdentifier?: string,
+	fieldIdentifierUnit?: string
 ) => {
 	const body = {
 		ParentNodeId: parentNodeId,
@@ -40,7 +42,9 @@ export const createAssessmentNode = async (
 		Required: required ? required : false,
 		ScoringApplicable: scoringApplicable ? scoringApplicable : false,
 		ResolutionScore: resolutionScore ? resolutionScore : null,
-		ProviderAssessmentCode: providerAssessmentCode ? providerAssessmentCode : null
+		ProviderAssessmentCode: providerAssessmentCode ? providerAssessmentCode : null,
+		FieldIdentifier: fieldIdentifier ? fieldIdentifier : null,
+		FieldIdentifierUnit: fieldIdentifierUnit ? fieldIdentifierUnit : null
 	};
 	// if (options && options.length > 0) {
 	// 	let count = 1;
@@ -103,8 +107,14 @@ export const updateAssessmentNode = async (
 	message?: string,
 	sequence?: number,
 	serveListNodeChildrenAtOnce?: boolean,
-	correctAnswer?: number|boolean,
-	rawData?: string
+	correctAnswer?: number | boolean | string,
+	rawData?: string,
+	scoringApplicable?: boolean,
+	resolutionScore?: number,
+	providerAssessmentCode?: string,
+	fieldIdentifier?: string,
+	fieldIdentifierUnit?: string
+
 
 ) => {
 	const body = {
@@ -119,6 +129,12 @@ export const updateAssessmentNode = async (
 		Tags: tags ? tags : [],
 		CorrectAnswer: correctAnswer ? correctAnswer : null,
 		RawData: rawData ? rawData : null,
+		ScoringApplicable: scoringApplicable ? scoringApplicable : false,
+		ResolutionScore: resolutionScore ? resolutionScore : null,
+		ProviderAssessmentCode: providerAssessmentCode ? providerAssessmentCode : null,
+		FieldIdentifier: fieldIdentifier ? fieldIdentifier : null,
+		FieldIdentifierUnit: fieldIdentifierUnit ? fieldIdentifierUnit : null
+
 
 	};
 	if (options && options.length > 0) {
@@ -226,7 +242,7 @@ export const updateOption = async (
 	console.log('body----------', body);
 	const url = BACKEND_API_URL + `/clinical/assessment-templates/${templateId}/nodes/${nodeId}/options/${optionId}`;
 	console.log(url);
-	
+
 	return await put(sessionId, url, body, true, API_CLIENT_INTERNAL_KEY);
 };
 

--- a/src/routes/api/services/reancare/assessments/assessment-templates.ts
+++ b/src/routes/api/services/reancare/assessments/assessment-templates.ts
@@ -120,6 +120,7 @@ export const updateAssessmentTemplate = async (
 		Tags: tags ? tags : []
 	};
 
+	console.log("assessment-body-----", body)
 	const url = BACKEND_API_URL + `/clinical/assessment-templates/${assessmentTemplateId}`;
 	return await put(sessionId, url, body, true, API_CLIENT_INTERNAL_KEY);
 };

--- a/src/routes/users/[userId]/assessment-templates/[templateId]/assessment-nodes/[nodeId]/edit/+page.svelte
+++ b/src/routes/users/[userId]/assessment-templates/[templateId]/assessment-nodes/[nodeId]/edit/+page.svelte
@@ -30,6 +30,8 @@
 		providerAssessmentCode = $state(data.assessmentNode.ProviderAssessmentCode),
 		scoringApplicable = $state(data.assessmentNode.ScoringApplicable),
 		required = $state(data.assessmentNode.Required),
+		fieldIdentifier = $state(data.assessmentNode.FieldIdentifier ?? undefined),
+		fieldIdentifierUnit = $state(data.assessmentNode.FieldIdentifierUnit ?? undefined),
 		rawData = $state(data.assessmentNode.RawData ?? undefined);
 
 	let optionArray = $derived(options);
@@ -59,6 +61,8 @@
 		providerAssessmentCode = data.assessmentNode.ProviderAssessmentCode;
 		scoringApplicable = data.assessmentNode.ScoringApplicable;
 		required = data.assessmentNode.Required;
+		fieldIdentifier = data.assessmentNode.FieldIdentifier ?? null;
+		fieldIdentifierUnit = data.assessmentNode.FieldIdentifierUnit ?? null;
 		errors = {};
 	}
 
@@ -79,6 +83,51 @@
 	];
 	let selectedNodeType = $derived(nodeType);
 	let selectedQueryType = $derived(queryType);
+
+	const AssessmentFieldIdentifiers = [
+		'General:PersonalProfile:FirstName',
+		'General:PersonalProfile:LastName',
+		'General:PersonalProfile:Name',
+		'General:PersonalProfile:Age',
+		'General:PersonalProfile:DateOfBirth',
+		'General:PersonalProfile:Gender',
+		'Clinical:HealthProfile:BloodGroup',
+		'Clinical:HealthProfile:Ethnicity',
+		'Clinical:HealthProfile:Race',
+		'Clinical:HealthProfile:MaritalStatus',
+		'Clinical:HealthProfile:Occupation',
+		'Clinical:HealthProfile:Smoking',
+		'Clinical:Vitals:BloodPressure:Systolic',
+		'Clinical:Vitals:BloodPressure:Diastolic',
+		'Clinical:Vitals:Pulse',
+		'Clinical:Vitals:RespiratoryRate',
+		'Clinical:Vitals:Temperature',
+		'Clinical:Vitals:Weight',
+		'Clinical:Vitals:Height',
+		'Clinical:Vitals:BodyMassIndex',
+		'Clinical:Vitals:OxygenSaturation',
+		'Clinical:Vitals:BloodGlucose',
+		'Clinical:LabRecords:Cholesterol',
+		'Clinical:LabRecords:Triglycerides',
+		'Clinical:LabRecords:LDL',
+		'Clinical:LabRecords:HDL',
+		'Clinical:LabRecords:Creatinine',
+		'Clinical:LabRecords:Urea',
+		'Clinical:LabRecords:Electrolytes',
+		'Clinical:LabRecords:Hemoglobin',
+		'Clinical:LabRecords:A1C',
+		'Clinical:LabRecords:Platelets',
+		'Clinical:LabRecords:WBC'
+	];
+
+	function toHumanLabel(identifier: string) {
+		const raw = identifier.split(':').pop() ?? '';
+		return raw.replace(/([a-z])([A-Z])/g, '$1 $2');
+	}
+
+	const sortedIdentifiers = AssessmentFieldIdentifiers.sort((a, b) =>
+		toHumanLabel(a).localeCompare(toHumanLabel(b))
+	);
 
 	const handleSubmit = async (event: Event) => {
 		try {
@@ -111,11 +160,14 @@
 				Message: message,
 				Tags: keywords,
 				RawData: rawData,
-				Required: required
+				Required: required,
+				FieldIdentifier: fieldIdentifier,
+				FieldIdentifierUnit: fieldIdentifierUnit
 			};
 
 			const validationResult = createOrUpdateSchema.safeParse(assessmentNodeUpdateModel);
 
+			console.log('validationResult', validationResult, "assessmentNodeUpdateModel", assessmentNodeUpdateModel);
 			if (!validationResult.success) {
 				errors = Object.fromEntries(
 					Object.entries(validationResult.error.flatten().fieldErrors).map(([key, val]) => [
@@ -254,6 +306,44 @@
 									keywordsChanged={onUpdateKeywords}
 								/>
 								<input type="hidden" name="keywordsStr" id="keywordsStr" bind:value={keywordsStr} />
+							</td>
+						</tr>
+						<tr>
+							<td>Field Identifier</td>
+							<td>
+								<select
+									name="fieldIdentifier"
+									bind:value={fieldIdentifier}
+									class="health-system-input {form?.errors?.fieldIdentifier
+										? 'input-text-error'
+										: ''}"
+								>
+									<option value="" disabled selected>Select fieldIdentifier here...</option>
+									{#each sortedIdentifiers as identifier}
+										<option value={identifier}>{toHumanLabel(identifier)}</option>
+									{/each}
+								</select>
+
+								{#if errors?.FieldIdentifier}
+									<p class="text-error">{errors?.FieldIdentifier}</p>
+								{/if}
+							</td>
+						</tr>
+						<tr>
+							<td class="align-top">Field Identifier Unit</td>
+							<td>
+								<input
+									type="text"
+									name="fieldIdentifierUnit"
+									bind:value={fieldIdentifierUnit}
+									placeholder="Enter fieldIdentifierUnit here...."
+									class="health-system-input {form?.errors?.fieldIdentifierUnit
+										? 'input-text-error'
+										: ''}"
+								/>
+								{#if errors?.FieldIdentifierUnit}
+									<p class="text-error">{errors?.FieldIdentifierUnit}</p>
+								{/if}
 							</td>
 						</tr>
 						{#if selectedNodeType === 'Question'}

--- a/src/routes/users/[userId]/assessment-templates/[templateId]/assessment-nodes/[nodeId]/view/+page.svelte
+++ b/src/routes/users/[userId]/assessment-templates/[templateId]/assessment-nodes/[nodeId]/view/+page.svelte
@@ -30,7 +30,12 @@
 	let tags_ = Array.isArray(assessmentNodes?.Tags) ? assessmentNodes.Tags : [];
 	let tags = tags_.join(', ');
 	let correctAnswer = assessmentNodes.CorrectAnswer ?? null;
-	let rawData = assessmentNodes.RawData ?? null;
+	let rawData = assessmentNodes.RawData !== null && assessmentNodes.RawData !== ''
+		? assessmentNodes.RawData
+		: 'Not specified';
+
+	let fieldIdentifier = assessmentNodes.FieldIdentifier ?? null;
+	let fieldIdentifierUnit = assessmentNodes.FieldIdentifierUnit ?? null;
 
 	let resolutionScore = $state();
 
@@ -174,6 +179,13 @@
 						<td>Sequence</td>
 						<td>{sequence}</td>
 					</tr>
+					<tr>
+						<td>Field Identifier</td>
+						<td>{fieldIdentifier}</td>
+					</tr>
+					<tr>
+						<td>Field Identifier Unit</td>
+						<td>{fieldIdentifierUnit}</td>	
 					<tr>
 						<td>Tags</td>
 						<td>

--- a/src/routes/users/[userId]/assessment-templates/[templateId]/assessment-nodes/create/+page.svelte
+++ b/src/routes/users/[userId]/assessment-templates/[templateId]/assessment-nodes/create/+page.svelte
@@ -31,6 +31,8 @@
 		message = $state(undefined),
 		keywords = $state(undefined),
 		required = $state(undefined),
+		fieldIdentifier = $state(undefined),
+		fieldIdentifierUnit = $state(undefined),
 		rawData = $state(undefined);
 
 	let errors: Record<string, string> = $state({});
@@ -76,6 +78,50 @@
 		}
 	];
 
+	const AssessmentFieldIdentifiers = [
+		'General:PersonalProfile:FirstName',
+		'General:PersonalProfile:LastName',
+		'General:PersonalProfile:Name',
+		'General:PersonalProfile:Age',
+		'General:PersonalProfile:DateOfBirth',
+		'General:PersonalProfile:Gender',
+		'Clinical:HealthProfile:BloodGroup',
+		'Clinical:HealthProfile:Ethnicity',
+		'Clinical:HealthProfile:Race',
+		'Clinical:HealthProfile:MaritalStatus',
+		'Clinical:HealthProfile:Occupation',
+		'Clinical:HealthProfile:Smoking',
+		'Clinical:Vitals:BloodPressure:Systolic',
+		'Clinical:Vitals:BloodPressure:Diastolic',
+		'Clinical:Vitals:Pulse',
+		// 'Clinical:Vitals:RespiratoryRate',
+		'Clinical:Vitals:Temperature',
+		'Clinical:Vitals:Weight',
+		'Clinical:Vitals:Height',
+		// 'Clinical:Vitals:BodyMassIndex',
+		'Clinical:Vitals:OxygenSaturation',
+		'Clinical:Vitals:BloodGlucose',
+		'Clinical:LabRecords:Cholesterol',
+		'Clinical:LabRecords:Triglycerides',
+		'Clinical:LabRecords:LDL',
+		'Clinical:LabRecords:HDL',
+		// 'Clinical:LabRecords:Creatinine',
+		// 'Clinical:LabRecords:Urea',
+		// 'Clinical:LabRecords:Electrolytes',
+		// 'Clinical:LabRecords:Hemoglobin',
+		'Clinical:LabRecords:A1C'
+		// 'Clinical:LabRecords:Platelets',
+		// 'Clinical:LabRecords:WBC'
+	];
+
+	const sortedIdentifiers = AssessmentFieldIdentifiers;
+
+	function toLabel(identifier: string) {
+		const parts = identifier.split(':');
+		const lastPart = parts[parts.length - 1];
+		return lastPart.replace(/([a-z])([A-Z])/g, '$1 $2'); // adds space before capital letters
+	}
+
 	const handleSubmit = async (event: Event) => {
 		try {
 			event.preventDefault();
@@ -99,9 +145,12 @@
 				Message: message,
 				Tags: keywords,
 				RawData: rawData,
-				Required: required
+				Required: required,
+				FieldIdentifier: fieldIdentifier,
+				FieldIdentifierUnit: fieldIdentifierUnit
 			};
 
+			console.log('assessmentNodeCreateModel', assessmentNodeCreateModel);
 			const validationResult = createOrUpdateSchema.safeParse(assessmentNodeCreateModel);
 
 			if (!validationResult.success) {
@@ -168,7 +217,7 @@
 								<select
 									name="nodeType"
 									placeholder="Select node type here..."
-									class="select w-full"
+									class="health-system-input {form?.errors?.nodeType ? 'input-text-error' : ''}"
 									onchange={(val) => onSelectNodeType(val)}
 								>
 									<option>Question</option>
@@ -263,16 +312,16 @@
 									name="sequence"
 									placeholder="Enter sequence here..."
 									min="1"
-									class="input"
 									step="1"
 									bind:value={sequence}
+									class="health-system-input {form?.errors?.sequence ? 'input-text-error' : ''}"
 								/>
 								{#if errors?.Sequence}
 									<p class="text-error">{errors?.Sequence}</p>
 								{/if}
 							</td>
 						</tr>
-						<tr class="!border-b-secondary-100 dark:!border-b-surface-700 !border-b">
+						<tr>
 							<td class="align-top">Tags</td>
 							<td>
 								<InputChips
@@ -284,6 +333,48 @@
 								<input type="hidden" name="keywordsStr" id="keywordsStr" bind:value={keywordsStr} />
 							</td>
 						</tr>
+						<tr>
+							<td>Field Identifier</td>
+							<td>
+								<select
+									name="fieldIdentifier"
+									bind:value={fieldIdentifier}
+									class="health-system-input {form?.errors?.fieldIdentifier
+										? 'input-text-error'
+										: ''}"
+								>
+									<option value="" disabled selected={fieldIdentifier === undefined}>
+										Select fieldIdentifier here...
+									</option>
+
+									{#each sortedIdentifiers as identifier}
+										<option value={identifier}>{toLabel(identifier)}</option>
+									{/each}
+								</select>
+
+								{#if errors?.FieldIdentifier}
+									<p class="text-error">{errors?.FieldIdentifier}</p>
+								{/if}
+							</td>
+						</tr>
+
+						<tr>
+							<td class="align-top">Field Identifier Unit</td>
+							<td>
+								<input
+									type="text"
+									name="fieldIdentifierUnit"
+									bind:value={fieldIdentifierUnit}
+									placeholder="Enter fieldIdentifierUnit here...."
+									class="health-system-input {form?.errors?.fieldIdentifierUnit
+										? 'input-text-error'
+										: ''}"
+								/>
+								{#if errors?.FieldIdentifierUnit}
+									<p class="text-error">{errors?.FieldIdentifierUnit}</p>
+								{/if}
+							</td>
+						</tr>
 						{#if selectedNodeType === 'Question'}
 							<tr>
 								<td class="align-top">Query Response Type <span class=" text-red-600">*</span></td>
@@ -291,7 +382,7 @@
 									<select
 										id="mySelect"
 										name="queryType"
-										class="select select-info w-full"
+										class="health-system-input {form?.errors?.queryType ? 'input-text-error' : ''}"
 										placeholder="Select query type here..."
 										onchange={(val) => onSelectQueryResponseType(val)}
 									>

--- a/src/routes/users/[userId]/assessment-templates/[templateId]/edit/+page.svelte
+++ b/src/routes/users/[userId]/assessment-templates/[templateId]/edit/+page.svelte
@@ -120,8 +120,8 @@
 						<tr>
 							<th>Edit Assessment Template</th>
 							<th class="text-end">
-								<a href={viewRoute} class="btn variant-soft-secondary -my-2 p-2">
-									<Icon icon="material-symbols:close-rounded" class="text-lg" />
+								<a href={viewRoute} class=" cancel-btn">
+									<Icon icon="material-symbols:close-rounded" />
 								</a>
 							</th>
 						</tr>
@@ -169,7 +169,7 @@
 										: ''}"
 								>
 									<option selected>{assessmentType}</option>
-									<option>Daily Update</option>
+									<!-- <option>Daily Update</option> -->
 									<option>Symptoms</option>
 									<option>Survey</option>
 									<option>Protocol</option>


### PR DESCRIPTION
Introduces `FieldIdentifier` and `FieldIdentifierUnit` properties to the assessment node creation and update models, enhancing the data structure to support additional metadata for assessment nodes.

Updates validation schema to include the new fields, ensuring proper handling during data entry and updates.

Modifies relevant API routes and user interfaces to accommodate these changes, allowing users to input and view field identifiers effectively.

Improves overall data integrity and usability for assessment nodes.