### PR TITLE
Refines assessment node titles and enhances data fetching

### DIFF
--- a/src/routes/users/[userId]/assessment-templates/[templateId]/assessment-nodes/+page.svelte
+++ b/src/routes/users/[userId]/assessment-templates/[templateId]/assessment-nodes/+page.svelte
@@ -37,7 +37,7 @@
 
 	const breadCrumbs = [
 		{ name: 'Assessments', path: assessmentRoute },
-		{ name: 'Assessment-Nodes', path: assessmentNodeRoute }
+		{ name: 'Nodes', path: assessmentNodeRoute }
 	];
 
 	let title = $state(undefined);

--- a/src/routes/users/[userId]/assessment-templates/[templateId]/assessment-nodes/[nodeId]/edit/+page.server.ts
+++ b/src/routes/users/[userId]/assessment-templates/[templateId]/assessment-nodes/[nodeId]/edit/+page.server.ts
@@ -1,16 +1,12 @@
-import { error, type RequestEvent } from '@sveltejs/kit';
-import { redirect } from 'sveltekit-flash-message/server';
-import { zfd } from 'zod-form-data';
-import { z } from 'zod';
-import { errorMessage, successMessage } from '$lib/utils/message.utils';
+import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 import {
     getAssessmentNodeById,
     getQueryResponseTypes,
     searchAssessmentNodes,
-    updateAssessmentNode
 } from '../../../../../../../api/services/reancare/assessments/assessment-nodes';
 import type { ServerLoadEvent } from '@sveltejs/kit';
+import { getAssessmentTemplateById } from '../../../../../../../api/services/reancare/assessments/assessment-templates';
 
 /////////////////////////////////////////////////////////////////////////
 
@@ -26,6 +22,7 @@ export const load: PageServerLoad = async (event: ServerLoadEvent) => {
     const _queryResponseTypes = await getQueryResponseTypes(sessionId);
     const _assessmentNodes = await searchAssessmentNodes(sessionId, searchParams);
     const response = await getAssessmentNodeById(sessionId, templateId, assessmentNodeId);
+    const templateDetails = await getAssessmentTemplateById(sessionId, templateId);
 
     if (response.Status === 'failure' || response.HttpCode !== 200) {
         throw error(response.HttpCode, response.Message);
@@ -34,95 +31,98 @@ export const load: PageServerLoad = async (event: ServerLoadEvent) => {
     const queryResponseTypes = _queryResponseTypes?.Data?.QueryResponseTypes;
     const assessmentNodes = _assessmentNodes?.Data?.AssessmentNodeRecords?.Items;
     const id = response?.Data?.AssessmentNode?.id;
+    const templateData = templateDetails?.Data?.AssessmentTemplate;
+
     return {
         location: `${id}/edit`,
         assessmentNode,
         queryResponseTypes,
         assessmentNodes,
+        templateData,
         message: response.Message,
         title: 'Clinical-Assessments-Assessment Nodes Edit',
         sessionId
     };
 };
 
-const updateAssessmentNodeSchema = zfd.formData({
-    nodeType: z.string(),
-    title: z.string().min(8).max(256),
-    description: z.string().optional(),
-    queryType: z.string().optional(),
-    resolutionScore: zfd.numeric(z.number().default(1)),
-    providerAssessmentCode: z.string().optional(),
-    message: z.string().optional(),
-    serveListNodeChildrenAtOnce: zfd.checkbox({ trueValue: 'true' }),
-    scoringApplicable: zfd.checkbox({ trueValue: 'true' }),
-    options: z.array(z.string()),
-    sequence: zfd.numeric(z.number().optional()),
-    tags: z.array(z.string()).optional(),
-    correctAnswer: z.string().optional()
+// const updateAssessmentNodeSchema = zfd.formData({
+//     nodeType: z.string(),
+//     title: z.string().min(8).max(256),
+//     description: z.string().optional(),
+//     queryType: z.string().optional(),
+//     resolutionScore: zfd.numeric(z.number().default(1)),
+//     providerAssessmentCode: z.string().optional(),
+//     message: z.string().optional(),
+//     serveListNodeChildrenAtOnce: zfd.checkbox({ trueValue: 'true' }),
+//     scoringApplicable: zfd.checkbox({ trueValue: 'true' }),
+//     options: z.array(z.string()),
+//     sequence: zfd.numeric(z.number().optional()),
+//     tags: z.array(z.string()).optional(),
+//     correctAnswer: z.string().optional()
 
-});
+// });
 
-export const actions = {
-    updateAssessmentNodeAction: async (event: RequestEvent) => {
-        const request = event.request;
-        const userId = event.params.userId;
-        const templateId = event.params.templateId;
-        const assessmentNodeId = event.params.nodeId;
-        const scoreConditionId = event.params.scoreConditionId;
-        const sessionId = event.cookies.get('sessionId');
-        const data = await request.formData();
-        const tags = data.has('tags') ? data.getAll('tags') : [];
-        const options = data.has('options') ? data.getAll('options') : [];
-        const formData = Object.fromEntries(data);
-        const formDataValue = { ...formData, options: options, tags: tags };
+// export const actions = {
+//     updateAssessmentNodeAction: async (event: RequestEvent) => {
+//         const request = event.request;
+//         const userId = event.params.userId;
+//         const templateId = event.params.templateId;
+//         const assessmentNodeId = event.params.nodeId;
+//         const scoreConditionId = event.params.scoreConditionId;
+//         const sessionId = event.cookies.get('sessionId');
+//         const data = await request.formData();
+//         const tags = data.has('tags') ? data.getAll('tags') : [];
+//         const options = data.has('options') ? data.getAll('options') : [];
+//         const formData = Object.fromEntries(data);
+//         const formDataValue = { ...formData, options: options, tags: tags };
 
-        console.log("Form data",formData)
+//         console.log("Form data", formData)
 
-        type AssessmentNodeSchema = z.infer<typeof updateAssessmentNodeSchema>;
+//         type AssessmentNodeSchema = z.infer<typeof updateAssessmentNodeSchema>;
 
-        let result: AssessmentNodeSchema = {};
-        try {
-            result = updateAssessmentNodeSchema.parse(formDataValue);
-            console.log('result', result);
-        } catch (err: any) {
-            const { fieldErrors: errors } = err.flatten();
-            console.log(errors);
-            const { ...rest } = formData;
-            return {
-                data: rest,
-                errors
-            };
-        }
+//         let result: AssessmentNodeSchema = {};
+//         try {
+//             result = updateAssessmentNodeSchema.parse(formDataValue);
+//             console.log('result', result);
+//         } catch (err: any) {
+//             const { fieldErrors: errors } = err.flatten();
+//             console.log(errors);
+//             const { ...rest } = formData;
+//             return {
+//                 data: rest,
+//                 errors
+//             };
+//         }
 
-        let response;
-        try {
-            response = await updateAssessmentNode(
-                sessionId,
-                templateId,
-                assessmentNodeId,
-                result.nodeType,
-                result.title,
-                result.description,
-                result.tags,
-                result.queryType,
-                result.options,
-                result.message,
-                result.sequence,
-                result.serveListNodeChildrenAtOnce,
-                result.correctAnswer
-            );
-        } catch (error: any) {
-            const errorMessageText = error?.body?.message || 'An error occurred';
-            throw redirect(303, `/users/${userId}/assessment-templates`, errorMessage(errorMessageText), event);
-        }
-        const nodeId = response.Data.AssessmentNode.id;
+//         let response;
+//         try {
+//             response = await updateAssessmentNode(
+//                 sessionId,
+//                 templateId,
+//                 assessmentNodeId,
+//                 result.nodeType,
+//                 result.title,
+//                 result.description,
+//                 result.tags,
+//                 result.queryType,
+//                 result.options,
+//                 result.message,
+//                 result.sequence,
+//                 result.serveListNodeChildrenAtOnce,
+//                 result.correctAnswer
+//             );
+//         } catch (error: any) {
+//             const errorMessageText = error?.body?.message || 'An error occurred';
+//             throw redirect(303, `/users/${userId}/assessment-templates`, errorMessage(errorMessageText), event);
+//         }
+//         const nodeId = response.Data.AssessmentNode.id;
 
-        console.log('response', response.Data);
-        throw redirect(
-            303,
-            `/users/${userId}/assessment-templates/${templateId}/assessment-nodes/${nodeId}/view`,
-            successMessage(`Assessment node updated successfully!`),
-            event
-        );
-    }
-};
+//         console.log('response', response.Data);
+//         throw redirect(
+//             303,
+//             `/users/${userId}/assessment-templates/${templateId}/assessment-nodes/${nodeId}/view`,
+//             successMessage(`Assessment node updated successfully!`),
+//             event
+//         );
+//     }
+// };

--- a/src/routes/users/[userId]/assessment-templates/[templateId]/assessment-nodes/[nodeId]/edit/+page.svelte
+++ b/src/routes/users/[userId]/assessment-templates/[templateId]/assessment-nodes/[nodeId]/edit/+page.svelte
@@ -14,6 +14,10 @@
 
 	let { data, form }: { data: PageServerData; form: any } = $props();
 
+	console.log(data, 'data from server');
+	let nodeTitle = data.assessmentNode.Title;
+	let templateTitle = data.templateData.Title;
+
 	let nodeType = $state(data.assessmentNode.NodeType),
 		parentNodeId = $state(data.assessmentNode.ParentNodeId),
 		title = $state(data.assessmentNode.Title),
@@ -77,8 +81,8 @@
 
 	const breadCrumbs = [
 		{ name: 'Assessments', path: assessmentsRoutes },
-		{ name: 'Assessment-View', path: assessmentTemplateView },
-		{ name: 'Assessment-Nodes', path: assessmentNodeRoutes },
+		{ name: templateTitle, path: assessmentTemplateView },
+		{ name: 'Nodes', path: assessmentNodeRoutes },
 		{ name: 'Edit', path: editRoute }
 	];
 	let selectedNodeType = $derived(nodeType);
@@ -100,34 +104,25 @@
 		'Clinical:Vitals:BloodPressure:Systolic',
 		'Clinical:Vitals:BloodPressure:Diastolic',
 		'Clinical:Vitals:Pulse',
-		'Clinical:Vitals:RespiratoryRate',
 		'Clinical:Vitals:Temperature',
 		'Clinical:Vitals:Weight',
 		'Clinical:Vitals:Height',
-		'Clinical:Vitals:BodyMassIndex',
 		'Clinical:Vitals:OxygenSaturation',
 		'Clinical:Vitals:BloodGlucose',
 		'Clinical:LabRecords:Cholesterol',
 		'Clinical:LabRecords:Triglycerides',
 		'Clinical:LabRecords:LDL',
 		'Clinical:LabRecords:HDL',
-		'Clinical:LabRecords:Creatinine',
-		'Clinical:LabRecords:Urea',
-		'Clinical:LabRecords:Electrolytes',
-		'Clinical:LabRecords:Hemoglobin',
-		'Clinical:LabRecords:A1C',
-		'Clinical:LabRecords:Platelets',
-		'Clinical:LabRecords:WBC'
+		'Clinical:LabRecords:A1C'
 	];
 
-	function toHumanLabel(identifier: string) {
-		const raw = identifier.split(':').pop() ?? '';
-		return raw.replace(/([a-z])([A-Z])/g, '$1 $2');
-	}
+	const sortedIdentifiers = AssessmentFieldIdentifiers;
 
-	const sortedIdentifiers = AssessmentFieldIdentifiers.sort((a, b) =>
-		toHumanLabel(a).localeCompare(toHumanLabel(b))
-	);
+	function toLabel(identifier: string) {
+		const parts = identifier.split(':');
+		const lastPart = parts[parts.length - 1];
+		return lastPart.replace(/([a-z])([A-Z])/g, '$1 $2'); // adds space before capital letters
+	}
 
 	const handleSubmit = async (event: Event) => {
 		try {
@@ -167,7 +162,12 @@
 
 			const validationResult = createOrUpdateSchema.safeParse(assessmentNodeUpdateModel);
 
-			console.log('validationResult', validationResult, "assessmentNodeUpdateModel", assessmentNodeUpdateModel);
+			console.log(
+				'validationResult',
+				validationResult,
+				'assessmentNodeUpdateModel',
+				assessmentNodeUpdateModel
+			);
 			if (!validationResult.success) {
 				errors = Object.fromEntries(
 					Object.entries(validationResult.error.flatten().fieldErrors).map(([key, val]) => [
@@ -218,7 +218,7 @@
 				<table class="health-system-table">
 					<thead>
 						<tr>
-							<th>Edit Assessment Node</th>
+							<th>Edit Node</th>
 							<th class="text-end">
 								<a href={viewRoute} class="health-system-btn variant-soft-secondary">
 									<Icon icon="material-symbols:close-rounded" />
@@ -320,7 +320,7 @@
 								>
 									<option value="" disabled selected>Select fieldIdentifier here...</option>
 									{#each sortedIdentifiers as identifier}
-										<option value={identifier}>{toHumanLabel(identifier)}</option>
+										<option value={identifier}>{toLabel(identifier)}</option>
 									{/each}
 								</select>
 

--- a/src/routes/users/[userId]/assessment-templates/[templateId]/assessment-nodes/[nodeId]/view/+page.server.ts
+++ b/src/routes/users/[userId]/assessment-templates/[templateId]/assessment-nodes/[nodeId]/view/+page.server.ts
@@ -10,8 +10,8 @@ export const load: PageServerLoad = async (event: RequestEvent) => {
 	const assessmentNodeId = event.params.nodeId;
 		const templateId = event.params.templateId;
 		const response = await getAssessmentNodeById(sessionId, templateId, assessmentNodeId);
-		const _templateScoringCondition = await getAssessmentTemplateById(sessionId, templateId);
-		const templateScoringCondition = _templateScoringCondition.Data.AssessmentTemplate;
+		const templateDetails_ = await getAssessmentTemplateById(sessionId, templateId);
+	const templateDetails = templateDetails_.Data.AssessmentTemplate;
 
 		if (response.Status === 'failure' || response.HttpCode !== 200) {
 			throw error(response.HttpCode, response.Message);
@@ -22,7 +22,7 @@ export const load: PageServerLoad = async (event: RequestEvent) => {
 			location: `${id}/edit`,
 			assessmentNode,
 			sessionId,
-			templateScoringCondition,
+			templateDetails,
 			message: response.Message,
 			title:'Clinical-Assessments-Assessment Nodes View'
 		};

--- a/src/routes/users/[userId]/assessment-templates/[templateId]/assessment-nodes/[nodeId]/view/+page.svelte
+++ b/src/routes/users/[userId]/assessment-templates/[templateId]/assessment-nodes/[nodeId]/view/+page.svelte
@@ -1,41 +1,48 @@
 <script lang="ts">
 	import BreadCrumbs from '$lib/components/breadcrumbs/breadcrums.svelte';
 	import { scoringApplicableCondition, showScoringConditionModal } from '$lib/store/general.store';
+	import UpdateScoringCondition from '$lib/components/modal/update.scoring.condition.modal.svelte';
 	import { Helper } from '$lib/utils/helper';
 	import Icon from '@iconify/svelte';
 	import type { PageServerData } from './$types';
 	import Tooltip from '$lib/components/tooltip.svelte';
 	import { page } from '$app/state';
+	import { createOrUpdateSchema } from '$lib/validation/scoring.condition.schema';
+	import { toastMessage } from '$lib/components/toast/toast.store';
 
 	////////////////////////////////////////////////////////////////////////////////////////////
 
 	let { data }: { data: PageServerData } = $props();
+	let errors: Record<string, string> = $state({});
+	let templateTitle = data.templateDetails.Title;
 
-	let sessionId = data.sessionId;
-	let assessmentNodes = $state(data.assessmentNode);
+console.log('This is data',data)
+	const assessmentNodes = $state(data.assessmentNode);
+	console.log('assessmentNodes', assessmentNodes);
 
-	let nodeType = assessmentNodes.NodeType;
-	let title = assessmentNodes.Title;
-	let description =
+	const nodeType = assessmentNodes.NodeType;
+	const title = assessmentNodes.Title;
+	const description =
 		assessmentNodes.Description !== null && assessmentNodes.Description !== ''
 			? assessmentNodes.Description
 			: 'Not specified';
-	let message = assessmentNodes.Message !== null ? assessmentNodes.Message : 'Not specified';
-	let serveListNodeChildrenAtOnce = assessmentNodes.ServeListNodeChildrenAtOnce ?? null;
-	let queryType = assessmentNodes.QueryResponseType;
-	let options = assessmentNodes.Options ?? [];
-	let childrenNodes = assessmentNodes.Children ?? [];
-	let displayCode = assessmentNodes.DisplayCode;
-	let sequence = assessmentNodes.Sequence;
-	let tags_ = Array.isArray(assessmentNodes?.Tags) ? assessmentNodes.Tags : [];
-	let tags = tags_.join(', ');
-	let correctAnswer = assessmentNodes.CorrectAnswer ?? null;
-	let rawData = assessmentNodes.RawData !== null && assessmentNodes.RawData !== ''
-		? assessmentNodes.RawData
-		: 'Not specified';
+	const message = assessmentNodes.Message !== null ? assessmentNodes.Message : 'Not specified';
+	const serveListNodeChildrenAtOnce = assessmentNodes.ServeListNodeChildrenAtOnce ?? null;
+	const queryType = assessmentNodes.QueryResponseType;
+	const options = assessmentNodes.Options ?? [];
+	const childrenNodes = assessmentNodes.Children ?? [];
+	const displayCode = assessmentNodes.DisplayCode;
+	const sequence = assessmentNodes.Sequence;
+	const tags_ = Array.isArray(assessmentNodes?.Tags) ? assessmentNodes.Tags : [];
+	const tags = tags_.join(', ');
+	const correctAnswer = assessmentNodes.CorrectAnswer ?? null;
+	const rawData =
+		assessmentNodes.RawData !== null && assessmentNodes.RawData !== ''
+			? assessmentNodes.RawData
+			: 'Not specified';
 
-	let fieldIdentifier = assessmentNodes.FieldIdentifier ?? null;
-	let fieldIdentifierUnit = assessmentNodes.FieldIdentifierUnit ?? null;
+	const fieldIdentifier = assessmentNodes.FieldIdentifier ?? null;
+	const fieldIdentifierUnit = assessmentNodes.FieldIdentifierUnit ?? null;
 
 	let resolutionScore = $state();
 
@@ -43,7 +50,7 @@
 		resolutionScore = assessmentNodes.ScoringCondition?.ResolutionScore;
 	}
 
-	scoringApplicableCondition.set(data.templateScoringCondition.ScoringApplicable);
+	scoringApplicableCondition.set(data.templateDetails.ScoringApplicable);
 
 	// console.log('assessmentNode', assessmentNodes);
 
@@ -65,11 +72,11 @@
 			path: assessmentsRoutes
 		},
 		{
-			name: 'Assessment-View',
+			name: templateTitle,
 			path: assessmentTemplateView
 		},
 		{
-			name: 'Assessment-Nodes',
+			name: 'Nodes',
 			path: assessmentNodeRoutes
 		},
 		{
@@ -93,33 +100,93 @@
 		window.location.href = viewRoute;
 	};
 
-	const onUpdateScoringCondition = async (resolutionScore: number) => {
-		const scoringId = data.assessmentNode.ScoringCondition.id;
-		console.log(scoringId);
-		await updateScoringCondition({
-			sessionId,
-			templateId,
-			nodeId,
-			scoringConditionId: data.assessmentNode.ScoringCondition.id,
-			resolutionScore: resolutionScore
-		});
+	let model = $state(false);
+
+	const openModal = async (event) => {
+		event.preventDefault();
+		event.stopPropagation();
+		model = true;
+	};
+	const closeModal = async () => {
+		model = false;
+	};
+	const onUpdateScoringCondition = async (score: number) => {
+		// const scoringId = data.assessmentNode.ScoringCondition.id;
+		// console.log(scoringId);
+		resolutionScore = score;
+		console.log('resolutionScore', resolutionScore);
+		handleSubmit(event);
 	};
 
-	async function updateScoringCondition(model) {
-		const response = await fetch(`/api/server/assessment-nodes/update-scoring-condition`, {
-			method: 'POST',
-			body: JSON.stringify(model),
-			headers: { 'content-type': 'application/json' }
-		});
-		const resp = await response.text();
-		const scoringCondition = JSON.parse(resp);
-		resolutionScore = scoringCondition.ResolutionScore;
-	}
+	const handleSubmit = async (event: Event) => {
+		try {
+			event.preventDefault();
+			errors = {};
+			const scoringId = data.assessmentNode.ScoringCondition ?? undefined;
+
+			const scoringConditionUpdateModel = {
+				ScoringConditionId: scoringId,
+				ResolutionScore: resolutionScore
+			};
+
+			const validationResult = createOrUpdateSchema.safeParse(scoringConditionUpdateModel);
+			console.log('validationResult', validationResult);
+
+			if (!validationResult.success) {
+				errors = Object.fromEntries(
+					Object.entries(validationResult.error.flatten().fieldErrors).map(([key, val]) => [
+						key,
+						val?.[0] || 'This field is required'
+					])
+				);
+				return;
+			}
+
+			const res = await fetch(
+				`/api/server/assessments/assessment-nodes/update-scoring-condition?templateId=${templateId}&nodeId=${nodeId}`,
+				{
+					method: 'PUT',
+					body: JSON.stringify(scoringConditionUpdateModel),
+					headers: { 'content-type': 'application/json' }
+				}
+			);
+
+			// console.log(scoringId);
+			const response = await res.json();
+			// const scoringCondition = JSON.parse(resp);
+
+			console.log('response', response);
+			if (response.HttpCode === 201 || response.HttpCode === 200) {
+				toastMessage(response);
+				// goto(`${assessmentsRoutes}/${response?.Data?.AssessmentTemplate?.id}/view`);
+				// resolutionScore = scoringCondition.ResolutionScore;
+				return;
+			}
+			if (response.Errors) {
+				errors = response?.Errors || {};
+			} else {
+				toastMessage(response);
+			}
+		} catch (error) {
+			toastMessage();
+		}
+	};
+
+	// async function updateScoringCondition(model) {
+	// 	const response = await fetch(`/api/server/assessment-nodes/update-scoring-condition`, {
+	// 		method: 'POST',
+	// 		body: JSON.stringify(model),
+	// 		headers: { 'content-type': 'application/json' }
+	// 	});
+	// }
 </script>
 
 <!-- <UpdateScoringCondition
 	on:updateScoringCondition={async (e) => await onUpdateScoringCondition(e.detail.resolutionScore)}
 /> -->
+{#if model}
+	<UpdateScoringCondition {onUpdateScoringCondition} {closeModal} />
+{/if}
 
 <BreadCrumbs crumbs={breadCrumbs} />
 
@@ -137,7 +204,7 @@
 			class="health-system-btn variant-filled-secondary hover:!variant-soft-secondary"
 		>
 			<Icon icon="material-symbols:edit-outline" />
-			<span>Edit</span>
+			<span class="ml-1">Edit</span>
 		</a>
 	</div>
 
@@ -146,7 +213,7 @@
 			<table class="health-system-table">
 				<thead>
 					<tr>
-						<th>View Assessment Node</th>
+						<th>View Node</th>
 						<th class="text-end">
 							<a href={assessmentNodeRoutes} class="cancel-btn">
 								<Icon icon="material-symbols:close-rounded" />
@@ -185,8 +252,8 @@
 					</tr>
 					<tr>
 						<td>Field Identifier Unit</td>
-						<td>{fieldIdentifierUnit}</td>	
-					<tr>
+						<td>{fieldIdentifierUnit}</td>
+					</tr><tr>
 						<td>Tags</td>
 						<td>
 							{#if tags.length <= 0}
@@ -241,7 +308,7 @@
 										<span>{resolutionScore}</span>
 
 										<button
-											onclick={async () => showScoringConditionModal.set(true)}
+											onclick={openModal}
 											class="px-2 text-center text-gray-500 hover:text-blue-600"
 										>
 											<Icon icon="material-symbols:edit-outline" class="text-lg" />

--- a/src/routes/users/[userId]/assessment-templates/[templateId]/assessment-nodes/create/+page.server.ts
+++ b/src/routes/users/[userId]/assessment-templates/[templateId]/assessment-nodes/create/+page.server.ts
@@ -1,15 +1,10 @@
-// import { redirect } from 'sveltekit-flash-message/server';
 import { error, type RequestEvent } from '@sveltejs/kit';
-// import { zfd } from 'zod-form-data';
-// import { z } from 'zod';
-// import { errorMessage, successMessage } from '$lib/utils/message.utils';
 import type { PageServerLoad } from './$types';
 import {
-    // addScoringCondition,
-    // createAssessmentNode,
     getQueryResponseTypes,
     searchAssessmentNodes
 } from '../../../../../../api/services/reancare/assessments/assessment-nodes';
+import { getAssessmentTemplateById } from '../../../../../../api/services/reancare/assessments/assessment-templates';
 
 /////////////////////////////////////////////////////////////////////////
 
@@ -21,16 +16,19 @@ export const load: PageServerLoad = async (event: RequestEvent) => {
     };
     const _queryResponseTypes = await getQueryResponseTypes(sessionId);
     const response = await searchAssessmentNodes(sessionId, searchParams);
+    const templateDetails = await getAssessmentTemplateById(sessionId, templateId);
 
     if (response.Status === 'failure' || response.HttpCode !== 200) {
         throw error(response.HttpCode, response.Message);
     }
     const queryResponseTypes = _queryResponseTypes?.Data?.QueryResponseTypes;
     const assessmentNodes = response?.Data?.AssessmentNodeRecords?.Items;
+    const templateData = templateDetails?.Data?.AssessmentTemplate;
 
     return {
         queryResponseTypes,
         assessmentNodes,
+        templateData,
         message: response.Message,
         title: 'Clinical-Assessments-Assessment Nodes Create'
     };

--- a/src/routes/users/[userId]/assessment-templates/[templateId]/assessment-nodes/create/+page.svelte
+++ b/src/routes/users/[userId]/assessment-templates/[templateId]/assessment-nodes/create/+page.svelte
@@ -15,6 +15,8 @@
 
 	let { data, form }: { data: PageServerData; form: any } = $props();
 
+	let templateTitle = data.templateData.Title;
+
 	const queryResponseTypes = data.queryResponseTypes;
 	const assessmentNodes = data.assessmentNodes;
 	let parentNodeId = $state(undefined),
@@ -65,11 +67,11 @@
 			path: assessmentsRoutes
 		},
 		{
-			name: 'Assessment-View',
+			name: templateTitle,
 			path: assessmentTemplateView
 		},
 		{
-			name: 'Assessment-Nodes',
+			name: 'Nodes',
 			path: assessmentNodeRoutes
 		},
 		{
@@ -202,7 +204,7 @@
 				<table class="health-system-table">
 					<thead>
 						<tr>
-							<th>Create Assessment Node</th>
+							<th>Create Node</th>
 							<th class="text-end">
 								<a href={assessmentNodeRoutes} class="health-system-btn variant-soft-secondary">
 									<Icon icon="material-symbols:close-rounded" />

--- a/src/routes/users/[userId]/assessment-templates/[templateId]/edit/+page.svelte
+++ b/src/routes/users/[userId]/assessment-templates/[templateId]/edit/+page.svelte
@@ -118,7 +118,7 @@
 				<table class="health-system-table">
 					<thead>
 						<tr>
-							<th>Edit Assessment Template</th>
+							<th>Edit Template</th>
 							<th class="text-end">
 								<a href={viewRoute} class=" cancel-btn">
 									<Icon icon="material-symbols:close-rounded" />

--- a/src/routes/users/[userId]/assessment-templates/[templateId]/view/+page.svelte
+++ b/src/routes/users/[userId]/assessment-templates/[templateId]/view/+page.svelte
@@ -67,14 +67,14 @@
 			href={nodeRoute}
 			class="health-system-btn variant-filled-secondary hover:!variant-soft-secondary"
 		>
-			Add Assessment Node</a
+			Add Node</a
 		>
 		<a
 			href={editRoute}
 			class="health-system-btn variant-filled-secondary hover:!variant-soft-secondary"
 		>
 			<Icon icon="material-symbols:edit-outline" />
-			<span>Edit</span>
+			<span class="ml-1">Edit</span>
 		</a>
 	</div>
 
@@ -83,7 +83,7 @@
 			<table class="health-system-table">
 				<thead>
 					<tr>
-						<th>View Assessment</th>
+						<th>View Template</th>
 						<th class="text-end">
 							<a href={assessmentsRoutes} class="cancel-btn">
 								<Icon icon="material-symbols:close-rounded" />

--- a/src/routes/users/[userId]/assessment-templates/create/+page.svelte
+++ b/src/routes/users/[userId]/assessment-templates/create/+page.svelte
@@ -103,7 +103,7 @@
 				<table class="health-system-table">
 					<thead>
 						<tr>
-							<th>Create Assessment Template</th>
+							<th>Create Template</th>
 							<th class="text-end">
 								<a href={assessmentsRoutes} class="health-system-btn variant-soft-secondary">
 									<Icon icon="material-symbols:close-rounded" />

--- a/src/routes/users/[userId]/assessment-templates/import/+page.svelte
+++ b/src/routes/users/[userId]/assessment-templates/import/+page.svelte
@@ -137,10 +137,10 @@
 				<div class="button-container">
 					{#await promise}
 						<button type="submit" class="health-system-btn variant-soft-secondary" disabled>
-							Submiting
+							Uploading...
 						</button>
 					{:then data}
-						<button type="submit" class="health-system-btn variant-soft-secondary"> Submit </button>
+						<button type="submit" class="health-system-btn variant-soft-secondary"> Upload </button>
 					{/await}
 				</div>
 			</form>


### PR DESCRIPTION
Updates breadcrumb titles for clarity, replacing 'Assessment-Nodes' with 'Nodes' and modifies various labels to improve user experience.

Enhances data retrieval by adding the fetching of assessment template details in several locations, ensuring that relevant information is consistently available throughout the application.

Removes unused code related to assessment node updating, streamlining the codebase.

Improves code readability and maintainability by adopting clearer naming conventions and reducing commented-out code.