### PR TITLE
Clears cache for related searches on updates/deletes

### DIFF
--- a/src/routes/api/services/reancare/health.systems.ts
+++ b/src/routes/api/services/reancare/health.systems.ts
@@ -15,23 +15,24 @@ export const createHealthSystem = async (
 	const url = BACKEND_API_URL + '/health-systems';
 	const result = await post(sessionId, url, body, true, API_CLIENT_INTERNAL_KEY);
 
-    const findAndClearKeys = [
-        `session-${sessionId}:req-searchHealthSystems`
-    ];
-    await DashboardManager.findAndClear(findAndClearKeys);
+	const findAndClearKeys = [`session-${sessionId}:req-searchHealthSystems`];
+	await DashboardManager.findAndClear(findAndClearKeys);
 
-    return result;
+	return result;
 };
 
 export const getHealthSystemById = async (sessionId: string, healthSystemId: string) => {
 	const url = BACKEND_API_URL + `/health-systems/${healthSystemId}`;
-    const cacheKey = `session-${sessionId}:req-getHealthSystemById-${healthSystemId}`;
-    if (await DashboardManager.has(cacheKey)) {
-        return await DashboardManager.get(cacheKey);
-    }
+
+	const cacheKey = `session-${sessionId}:req-getHealthSystemById-${healthSystemId}`;
+
+	if (await DashboardManager.has(cacheKey)) {
+		return await DashboardManager.get(cacheKey);
+	}
+
 	const result = await get(sessionId, url, true, API_CLIENT_INTERNAL_KEY);
-    await DashboardManager.set(cacheKey, result);
-    return result;
+	await DashboardManager.set(cacheKey, result);
+	return result;
 };
 
 export const searchHealthSystems = async (sessionId: string, searchParams?) => {
@@ -51,14 +52,15 @@ export const searchHealthSystems = async (sessionId: string, searchParams?) => {
 		}
 	}
 	const url = BACKEND_API_URL + `/health-systems/search${searchString}`;
-    const cacheKey = `session-${sessionId}:req-searchHealthSystems:${searchString}`;
-    if (await DashboardManager.has(cacheKey)) {
-        return await DashboardManager.get(cacheKey);
-    }
+
+	const cacheKey = `session-${sessionId}:req-searchHealthSystems:${searchString}`;
+	if (await DashboardManager.has(cacheKey)) {
+		return await DashboardManager.get(cacheKey);
+	}
 
 	const result = await get(sessionId, url, true, API_CLIENT_INTERNAL_KEY);
-    await DashboardManager.set(cacheKey, result);
-    return result;
+	await DashboardManager.set(cacheKey, result);
+	return result;
 };
 
 export const updateHealthSystem = async (
@@ -74,36 +76,34 @@ export const updateHealthSystem = async (
 	};
 	const url = BACKEND_API_URL + `/health-systems/${healthSystemId}`;
 	const result = await put(sessionId, url, body, true, API_CLIENT_INTERNAL_KEY);
-    const keysToBeDeleted = [
-        `session-${sessionId}:req-getHealthSystemById-${healthSystemId}`,
-    ];
-    await DashboardManager.deleteMany(keysToBeDeleted);
-    const findAndClearKeys = [
-        `session-${sessionId}:req-searchHealthSystems`,
-    ];
-    await DashboardManager.findAndClear(findAndClearKeys);
 
-    return result;
+	const keysToBeDeleted = [`session-${sessionId}:req-getHealthSystemById-${healthSystemId}`,];
+	await DashboardManager.deleteMany(keysToBeDeleted);
+
+	const findAndClearKeys = [`session-${sessionId}:req-searchHealthSystems`,];
+	await DashboardManager.findAndClear(findAndClearKeys);
+
+	return result;
 };
 
 export const deleteHealthSystem = async (sessionId: string, healthSystemId: string) => {
 	const url = BACKEND_API_URL + `/health-systems/${healthSystemId}`;
 	const result = await del(sessionId, url, true, API_CLIENT_INTERNAL_KEY);
 
-    const keysToBeDeleted = [
-        `session-${sessionId}:req-getHealthSystemById-${healthSystemId}`,
-    ];
-    await DashboardManager.deleteMany(keysToBeDeleted);
+	const keysToBeDeleted = [`session-${sessionId}:req-getHealthSystemById-${healthSystemId}`,];
+	await DashboardManager.deleteMany(keysToBeDeleted);
 
-    const findAndClearKeys = [
-        `session-${sessionId}:req-searchHealthSystems`,
-    ];
-    await DashboardManager.findAndClear(findAndClearKeys);
+	const findAndClearKeys = [
+		`session-${sessionId}:req-searchHealthSystems`,
+		`session-${sessionId}:req-searchHospitals`,
+		`session-${sessionId}:req-getHospitalsForHealthSystem`
+	];
+	await DashboardManager.findAndClear(findAndClearKeys);
 
-    return result;
+	return result;
 };
 
 export const getHealthSystemsForTags = async (sessionId: string, tag: string) => {
-    const url = BACKEND_API_URL + `/health-systems/by-tags/${tag}`;
-    return await get(sessionId, url, true, API_CLIENT_INTERNAL_KEY);
+	const url = BACKEND_API_URL + `/health-systems/by-tags/${tag}`;
+	return await get(sessionId, url, true, API_CLIENT_INTERNAL_KEY);
 };

--- a/src/routes/api/services/reancare/hospitals.ts
+++ b/src/routes/api/services/reancare/hospitals.ts
@@ -16,25 +16,25 @@ export const createHospital = async (
 		Tags: tags ? tags : []
 	};
 	const url = BACKEND_API_URL + '/hospitals';
-		const result = await post(sessionId, url, body, true, API_CLIENT_INTERNAL_KEY);
-	
-		const findAndClearKeys = [
-			`session-${sessionId}:req-searchHospitals`
-		];
-		await DashboardManager.findAndClear(findAndClearKeys);
-	
-		return result;
+	const result = await post(sessionId, url, body, true, API_CLIENT_INTERNAL_KEY);
+
+	const findAndClearKeys = [
+		`session-${sessionId}:req-searchHospitals`
+	];
+	await DashboardManager.findAndClear(findAndClearKeys);
+
+	return result;
 };
 
 export const getHospitalById = async (sessionId: string, hospitalId: string) => {
 	const url = BACKEND_API_URL + `/hospitals/${hospitalId}`;
-	    const cacheKey = `session-${sessionId}:req-getHospitalById-${hospitalId}`;
-    if (await DashboardManager.has(cacheKey)) {
-        return await DashboardManager.get(cacheKey);
-    }
+	const cacheKey = `session-${sessionId}:req-getHospitalById-${hospitalId}`;
+	if (await DashboardManager.has(cacheKey)) {
+		return await DashboardManager.get(cacheKey);
+	}
 	const result = await get(sessionId, url, true, API_CLIENT_INTERNAL_KEY);
-    await DashboardManager.set(cacheKey, result);
-    return result;
+	await DashboardManager.set(cacheKey, result);
+	return result;
 };
 
 export const searchHospitals = async (sessionId: string, searchParams?) => {
@@ -54,14 +54,14 @@ export const searchHospitals = async (sessionId: string, searchParams?) => {
 		}
 	}
 	const url = BACKEND_API_URL + `/hospitals/search${searchString}`;
-    const cacheKey = `session-${sessionId}:req-searchHospitals:${searchString}`;
-    if (await DashboardManager.has(cacheKey)) {
-        return await DashboardManager.get(cacheKey);
-    }
+	const cacheKey = `session-${sessionId}:req-searchHospitals:${searchString}`;
+	if (await DashboardManager.has(cacheKey)) {
+		return await DashboardManager.get(cacheKey);
+	}
 
 	const result = await get(sessionId, url, true, API_CLIENT_INTERNAL_KEY);
-    await DashboardManager.set(cacheKey, result);
-    return result;
+	await DashboardManager.set(cacheKey, result);
+	return result;
 };
 
 export const updateHospital = async (
@@ -78,39 +78,40 @@ export const updateHospital = async (
 		Tags: tags ? tags : null
 	};
 	console.log("body", body);
-	
-	const url = BACKEND_API_URL + `/hospitals/${hospitalId}`;
-		const result = await put(sessionId, url, body, true, API_CLIENT_INTERNAL_KEY);
-    const keysToBeDeleted = [
-        `session-${sessionId}:req-getHospitalById-${healthSystemId}`,
-    ];
-    await DashboardManager.deleteMany(keysToBeDeleted);
-    const findAndClearKeys = [
-        `session-${sessionId}:req-searchHospitals`,
-    ];
-    await DashboardManager.findAndClear(findAndClearKeys);
 
-    return result;
+	const url = BACKEND_API_URL + `/hospitals/${hospitalId}`;
+	const result = await put(sessionId, url, body, true, API_CLIENT_INTERNAL_KEY);
+	const keysToBeDeleted = [
+		`session-${sessionId}:req-getHospitalById-${hospitalId}`,
+	];
+	await DashboardManager.deleteMany(keysToBeDeleted);
+	const findAndClearKeys = [
+		`session-${sessionId}:req-searchHospitals`,
+		`session-${sessionId}:req-getHospitalsForHealthSystem`
+	];
+	await DashboardManager.findAndClear(findAndClearKeys);
+
+	return result;
 };
 
 export const deleteHospital = async (sessionId: string, hospitalId: string) => {
 	const url = BACKEND_API_URL + `/hospitals/${hospitalId}`;
-		const result = await del(sessionId, url, true, API_CLIENT_INTERNAL_KEY);
-	
-		const keysToBeDeleted = [
-			`session-${sessionId}:req-getHospitalById-${hospitalId}`,
-		];
-		await DashboardManager.deleteMany(keysToBeDeleted);
-	
-		const findAndClearKeys = [
-			`session-${sessionId}:req-searchHospitals`,
-		];
-		await DashboardManager.findAndClear(findAndClearKeys);
-	
-		return result;
+	const result = await del(sessionId, url, true, API_CLIENT_INTERNAL_KEY);
+
+	const keysToBeDeleted = [
+		`session-${sessionId}:req-getHospitalById-${hospitalId}`,
+	];
+	await DashboardManager.deleteMany(keysToBeDeleted);
+
+	const findAndClearKeys = [
+		`session-${sessionId}:req-searchHospitals`,
+	];
+	await DashboardManager.findAndClear(findAndClearKeys);
+
+	return result;
 };
 
 export const getHospitalsForHealthSystem = async (sessionId: string, healthSystemId: string) => {
-    const url = BACKEND_API_URL + `/hospitals/health-systems/${healthSystemId}`;
-    return await get(sessionId, url, true, API_CLIENT_INTERNAL_KEY);
+	const url = BACKEND_API_URL + `/hospitals/health-systems/${healthSystemId}`;
+	return await get(sessionId, url, true, API_CLIENT_INTERNAL_KEY);
 };


### PR DESCRIPTION
Ensures that related search caches for hospitals and health systems are cleared when entities are updated or deleted.

This prevents stale data from being displayed after an update or deletion operation.