### PR TITLE
Updates tenant list page index

### DIFF
--- a/src/routes/users/[userId]/tenants/+page.svelte
+++ b/src/routes/users/[userId]/tenants/+page.svelte
@@ -121,7 +121,7 @@
 			name: nameSearch,
 			code: codeSearch,
 			itemsPerPage: paginationSettings.limit,
-			pageIndex: 0,
+			pageIndex: paginationSettings.page,
 			sortBy,
 			sortOrder
 		});
@@ -138,7 +138,7 @@
 			name: nameSearch,
 			code: codeSearch,
 			itemsPerPage: paginationSettings.limit,
-			pageIndex: 0,
+			pageIndex: paginationSettings.page,
 			sortBy,
 			sortOrder
 		});
@@ -149,7 +149,7 @@
 			name: nameSearch,
 			code: codeSearch,
 			itemsPerPage: paginationSettings.limit,
-			pageIndex: 0,
+			pageIndex: paginationSettings.page,
 			sortBy,
 			sortOrder
 		});
@@ -174,7 +174,7 @@
 			name: nameSearch,
 			code: codeSearch,
 			itemsPerPage: paginationSettings.limit,
-			pageIndex: 0,
+			pageIndex: paginationSettings.page,
 			sortBy,
 			sortOrder
 		});


### PR DESCRIPTION
Updates the tenant list page index to use the pagination settings page value, ensuring correct page display when navigating between pages.

Previously, the page index was hardcoded to 0, causing the tenant list to always display the first page, regardless of the current pagination state.